### PR TITLE
Fix page container

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -165,7 +165,7 @@
 /* Prevent body scroll on mobile when content fits */
 @media screen and (max-device-width: 480px) {
   html, body {
-    height: 100%;
+    min-height: 100%;
     overflow-x: hidden;
   }
   
@@ -207,7 +207,7 @@
   
   body {
     -webkit-overflow-scrolling: touch;
-    overscroll-behavior: contain;
+    overscroll-behavior: auto;
   }
   
   /* Prevent iOS zoom on input focus */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -171,8 +171,6 @@
   
   body {
     -webkit-text-size-adjust: none;
-    position: fixed;
-    width: 100%;
   }
   
   #logo {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,9 +21,10 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background relative overflow-x-hidden">
-      <div id="gradient" className="h-full w-full">
-        <div className="flex flex-col items-center justify-center h-full pb-20">
+    <div className="min-h-dvh bg-background ios-safe-bottom overflow-x-hidden flex flex-col relative">
+      <div id="gradient" className="flex flex-col flex-1 h-full w-full">
+        <div className="h-[2dvh]" aria-hidden="true" />
+        <div className="flex flex-col items-center justify-center flex-1 pb-20">
                       <div id="main" className="text-muted-foreground w-full min-h-[550px] h-full">
             {/* Vertical centered content */}
             <div 
@@ -91,10 +92,12 @@ export default function Home() {
           </div>
         </div>
         
-        {/* Footer - Fixed to bottom */}
-        <div 
-          id="footer" 
-          className="fixed bottom-0 left-0 right-0 pb-[15px] text-xs w-full text-center text-muted-foreground animate-[fadeInUp_1s_ease-out]"
+        <div className="h-[2dvh]" aria-hidden="true" />
+
+        {/* Footer */}
+        <div
+          id="footer"
+          className="mt-auto pb-[15px] text-xs w-full text-center text-muted-foreground animate-[fadeInUp_1s_ease-out]"
           style={{ fontFamily: 'var(--font-ubuntu)' }}
         >
           <div id="copyright" className="text-[11px] w-full text-center text-muted-foreground">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background overflow-hidden relative">
+    <div className="min-h-screen bg-background relative overflow-x-hidden">
       <div id="gradient" className="h-full w-full">
         <div className="flex flex-col items-center justify-center h-full pb-20">
                       <div id="main" className="text-muted-foreground w-full min-h-[550px] h-full">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,10 +22,10 @@ export default function Home() {
 
   return (
     <div className="min-h-dvh bg-background ios-safe-bottom overflow-x-hidden flex flex-col relative">
-      <div id="gradient" className="flex flex-col flex-1 h-full w-full">
+      <div id="gradient" className="flex flex-col flex-1 w-full">
         <div className="h-[2dvh]" aria-hidden="true" />
         <div className="flex flex-col items-center justify-center flex-1 pb-20">
-                      <div id="main" className="text-muted-foreground w-full min-h-[550px] h-full">
+                      <div id="main" className="text-muted-foreground w-full min-h-[550px]">
             {/* Vertical centered content */}
             <div 
               className="absolute w-full transform -translate-y-1/2"

--- a/src/components/link-preview.tsx
+++ b/src/components/link-preview.tsx
@@ -202,7 +202,7 @@ export default function LinkPreview({ id, destination, trackingData, host = 'thi
     };
 
     return (
-        <div className="min-h-screen bg-background overflow-hidden relative">
+        <div className="min-h-screen bg-background relative overflow-x-hidden">
             <div className="flex flex-col items-center justify-center h-full pb-20">
                 <div className="text-muted-foreground w-full min-h-[550px] h-full">
                     <div 

--- a/src/components/link-preview.tsx
+++ b/src/components/link-preview.tsx
@@ -202,16 +202,11 @@ export default function LinkPreview({ id, destination, trackingData, host = 'thi
     };
 
     return (
-        <div className="min-h-screen bg-background relative overflow-x-hidden">
-            <div className="flex flex-col items-center justify-center h-full pb-20">
-                <div className="text-muted-foreground w-full min-h-[550px] h-full">
-                    <div 
-                        className="absolute w-full transform -translate-y-1/2"
-                        style={{ 
-                            top: '50%',
-                        }}
-                    >
-                        <div className="max-w-4xl mx-auto px-6">
+        <div className="min-h-dvh bg-background ios-safe-bottom flex flex-col overflow-x-hidden">
+            <div className="flex flex-col items-center justify-center flex-1 pb-20">
+                <div className="text-muted-foreground w-full min-h-[550px]">
+                    <div className="h-[2dvh]" aria-hidden="true" />
+                    <div className="max-w-4xl mx-auto px-6">
                             {/* Logo */}
                             <div className="text-center mb-8">
                                 <h1 
@@ -355,11 +350,12 @@ export default function LinkPreview({ id, destination, trackingData, host = 'thi
                         </div>
                     </div>
                 </div>
-            </div>
-            
+
+            <div className="h-[2dvh]" aria-hidden="true" />
+
             {/* Footer */}
-            <div 
-                className="fixed bottom-0 left-0 right-0 pb-[15px] text-xs w-full text-center text-muted-foreground"
+            <div
+                className="mt-auto pb-[15px] text-xs w-full text-center text-muted-foreground"
                 style={{ fontFamily: 'var(--font-ubuntu)' }}
             >
                 <div className="text-[11px] w-full text-center text-muted-foreground">


### PR DESCRIPTION
## Summary
- allow page to scroll normally by removing `position: fixed` on body
- stop clamping page overflow on homepage and link previews