### PR TITLE
Fix nested container scrolling issue

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -162,31 +162,6 @@
   }
 }
 
-/* Prevent body scroll on mobile when content fits */
-@media screen and (max-device-width: 480px) {
-  html, body {
-    height: 100%;
-    overflow-x: hidden;
-  }
-  
-  body {
-    -webkit-text-size-adjust: none;
-    position: fixed;
-    width: 100%;
-  }
-  
-  #logo {
-    top: 20px;
-  }
-  
-  .vertical-center {
-    top: 34% !important;
-  }
-  
-  #top {
-    height: 229px;
-  }
-}
 
 /* Use dynamic viewport height for better mobile support */
 @supports (height: 100dvh) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background overflow-hidden relative">
+    <div className="min-h-screen bg-background relative">
       <div id="gradient" className="h-full w-full">
         <div className="flex flex-col items-center justify-center h-full pb-20">
                       <div id="main" className="text-muted-foreground w-full min-h-[550px] h-full">

--- a/src/components/link-preview.tsx
+++ b/src/components/link-preview.tsx
@@ -202,7 +202,7 @@ export default function LinkPreview({ id, destination, trackingData, host = 'thi
     };
 
     return (
-        <div className="min-h-screen bg-background overflow-hidden relative">
+        <div className="min-h-screen bg-background relative">
             <div className="flex flex-col items-center justify-center h-full pb-20">
                 <div className="text-muted-foreground w-full min-h-[550px] h-full">
                     <div 


### PR DESCRIPTION
## Summary
- remove body-fixed mobile CSS workaround
- let main pages use normal scrolling

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688927a60ef4832da318d7f84002b0c8