### PR TITLE
Move import function to client side

### DIFF
--- a/src/components/admin/link-importer.tsx
+++ b/src/components/admin/link-importer.tsx
@@ -61,6 +61,17 @@ interface ShortenedUrl {
   ip?: string;
 }
 
+interface RawImportItem {
+  id?: string | number | null;
+  destination?: string | null;
+  createdAt?: string | null;
+  source?: string | null;
+  status?: string | null;
+  owner?: string | null;
+  ip?: string | null;
+  [key: string]: unknown; // Allow additional properties from database objects
+}
+
 interface ImportResult {
   successful: ShortenedUrl[];
   duplicates: ImportLink[];
@@ -106,10 +117,10 @@ export default function LinkImporter() {
   const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
 
 
-  const toShortenedUrls = (items: any[]): ShortenedUrl[] => {
+  const toShortenedUrls = (items: RawImportItem[]): ShortenedUrl[] => {
     return (items || [])
-      .filter((item: any) => item?.id && item?.destination)
-      .map((item: any) => ({
+      .filter((item: RawImportItem) => item?.id && item?.destination)
+      .map((item: RawImportItem) => ({
         id: String(item.id),
         destination: String(item.destination),
         createdAt: item.createdAt ?? undefined,

--- a/src/components/admin/link-importer.tsx
+++ b/src/components/admin/link-importer.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Progress } from '@/components/ui/progress';
+import { importLinks } from '@/utilities/import-links';
 
 interface ImportLink {
   id: string;
@@ -104,6 +105,20 @@ export default function LinkImporter() {
   const [showForceUpdateDialog, setShowForceUpdateDialog] = useState(false);
   const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
 
+
+  const toShortenedUrls = (items: any[]): ShortenedUrl[] => {
+    return (items || [])
+      .filter((item: any) => item?.id && item?.destination)
+      .map((item: any) => ({
+        id: String(item.id),
+        destination: String(item.destination),
+        createdAt: item.createdAt ?? undefined,
+        source: item.source ?? undefined,
+        status: item.status ?? undefined,
+        owner: item.owner ?? undefined,
+        ip: item.ip ?? undefined,
+      }));
+  };
 
   const parseCSV = useCallback((csvText: string): ImportLink[] => {
     const lines = csvText.trim().split('\n');
@@ -227,28 +242,33 @@ export default function LinkImporter() {
       }
 
       // Filter to only valid links (have id and destination)
-      const validLinks = parsedLinks.filter(link => link.id && link.destination);
+      const validLinks = parsedLinks.filter(link => link.id && link.destination).map(link => ({
+        id: link.id,
+        destination: link.destination
+      }));
 
       console.log('[LinkImporter] Starting import of', validLinks.length, 'links');
 
-      const response = await fetch('/api/v2/admin/import', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          links: validLinks,
-          updateDuplicates: false
-        })
-      });
+      // const response = await fetch('/api/v2/admin/import', {
+      //   method: 'POST',
+      //   headers: { 'Content-Type': 'application/json' },
+      //   body: JSON.stringify({
+      //     links: validLinks,
+      //     updateDuplicates: false
+      //   })
+      // });
 
-      const data = await response.json();
+      // const data = await response.json();
 
-      if (!response.ok) {
-        throw new Error(data.error || 'Import failed');
-      }
+      // if (!response.ok) {
+      //   throw new Error(data.error || 'Import failed');
+      // }
+
+      const data = await importLinks(validLinks, false);
 
       // Handle the response from the new API
-      const successful = data.successfulImports || [];
-      const duplicates = data.failedImports || [];
+      const successful = toShortenedUrls(data?.successfulImports || []);
+      const duplicates = data?.failedImports || [];
 
       setImportResult({
         successful,
@@ -336,24 +356,26 @@ export default function LinkImporter() {
 
       console.log('[LinkImporter] Force updating', importResult.duplicates.length, 'duplicates');
 
-      const response = await fetch('/api/v2/admin/import', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          links: importResult.duplicates,
-          updateDuplicates: true
-        })
-      });
+      // const response = await fetch('/api/v2/admin/import', {
+      //   method: 'POST',
+      //   headers: { 'Content-Type': 'application/json' },
+      //   body: JSON.stringify({
+      //     links: importResult.duplicates,
+      //     updateDuplicates: true
+      //   })
+      // });
 
-      const data = await response.json();
+      // const data = await response.json();
 
-      if (!response.ok) {
-        throw new Error(data.error || 'Force update failed');
-      }
+      // if (!response.ok) {
+      //   throw new Error(data.error || 'Force update failed');
+      // }
+
+      const data = await importLinks(importResult.duplicates, true);
 
       // Handle the response from force update
-      const successful = data.successfulImports || [];
-      const stillFailed = data.failedImports || [];
+      const successful = toShortenedUrls(data?.successfulImports || []);
+      const stillFailed = data?.failedImports || [];
 
       // Update the import result to remove successfully updated duplicates
       setImportResult(prev => prev ? {

--- a/src/utilities/import-links.ts
+++ b/src/utilities/import-links.ts
@@ -130,7 +130,19 @@ export const importLinks = async (links: LinkToImport[], updateDuplicates: boole
             } else {
                 if (updateDuplicates) {
                     // console.log('[IMPORT] Create returned no id; attempting update for potential duplicate', { id: linkData.id });
-                    await client.models.ShortenedUrl.update(linkData, { authMode: 'userPool' });
+                    try {
+                        const updateResult = await client.models.ShortenedUrl.update(linkData, { authMode: 'userPool' });
+                        if (updateResult?.data?.id) {
+                            // console.log('[IMPORT] Updated ShortenedUrl', { id: updateResult.data.id });
+                            successfulImports.push(updateResult.data);
+                        } else {
+                            // console.warn('[IMPORT] Update operation failed or returned no data', { id: linkData.id });
+                            failedImports.push(link);
+                        }
+                    } catch (updateError) {
+                        // console.error('[IMPORT] Update operation threw error', { id: linkData.id, error: updateError });
+                        failedImports.push(link);
+                    }
                 } else {
                     // console.warn('[IMPORT] Failed to create ShortenedUrl and duplicates not updated; marking as failed', { id: linkData.id });
                     failedImports.push(link);

--- a/src/utilities/import-links.ts
+++ b/src/utilities/import-links.ts
@@ -105,7 +105,6 @@ export const importLinks = async (links: LinkToImport[], updateDuplicates: boole
 
         for (const link of links) {
             currentIndex++;
-            console.clear();
             console.log(`[IMPORT] Processing ${currentIndex}/${links.length}`);
 
             // Prepare the data object with required fields

--- a/src/utilities/import-links.ts
+++ b/src/utilities/import-links.ts
@@ -34,6 +34,7 @@ const sanitizeUrl = (url: string): string => {
         return urlObj.toString();
     } catch (error) {
         // If URL constructor fails, do basic encoding of spaces and return
+        console.log('[IMPORT] sanitizeUrl error', error);
         return sanitized.replace(/\s+/g, '%20');
     }
 };

--- a/src/utilities/import-links.ts
+++ b/src/utilities/import-links.ts
@@ -141,6 +141,7 @@ export const importLinks = async (links: LinkToImport[], updateDuplicates: boole
                         }
                     } catch (updateError) {
                         // console.error('[IMPORT] Update operation threw error', { id: linkData.id, error: updateError });
+                        console.log('[IMPORT] Update operation threw error', { id: linkData.id, error: updateError });
                         failedImports.push(link);
                     }
                 } else {

--- a/src/utilities/import-links.ts
+++ b/src/utilities/import-links.ts
@@ -1,0 +1,152 @@
+import { generateClient } from "aws-amplify/api";
+import { Schema } from "../../amplify/data/resource";
+
+interface LinkToImport {
+    id: string;
+    destination: string;
+}
+
+interface ShortenedUrlData {
+    id: string;
+    destination: string;
+    source: 'upload' | 'manual' | 'api' | 'import';
+    createdAt?: string;
+    ip?: string;
+    owner?: string | null;
+    status?: 'active' | 'reported' | 'inactive';
+}
+
+const client = generateClient<Schema>();
+
+// Function to sanitize and validate URLs
+const sanitizeUrl = (url: string): string => {
+    // Trim whitespace
+    let sanitized = url.trim();
+    
+    // If URL doesn't start with a protocol, assume https
+    if (!sanitized.match(/^https?:\/\//i)) {
+        sanitized = 'https://' + sanitized;
+    }
+    
+    try {
+        // Use URL constructor to validate and normalize the URL
+        const urlObj = new URL(sanitized);
+        return urlObj.toString();
+    } catch (error) {
+        // If URL constructor fails, do basic encoding of spaces and return
+        return sanitized.replace(/\s+/g, '%20');
+    }
+};
+
+export const importLinks = async (links: LinkToImport[], updateDuplicates: boolean = false) => {
+
+    const updateIterator = async (increment: number) => {
+        // Step 1: Increment iterator by the number of successfully processed links
+        // console.log('[IMPORT] updateIterator: increment', { increment });
+        const iterator = await client.models.iterator.get({
+            id: 'lytnit'
+        }, { authMode: 'userPool' });
+
+        if (iterator?.data?.iteration !== undefined) {
+            await client.models.iterator.update({
+                id: 'lytnit',
+                iteration: increment
+            }, { authMode: 'userPool' });
+        } else {
+            // If iterator doesn't exist yet, create it starting at the increment value
+            await client.models.iterator.create({
+                id: 'lytnit',
+                iteration: increment
+            }, { authMode: 'userPool' });
+        }
+
+        // Step 2: Generate new IDs using vainId until we hit one that isn't a duplicate
+        // This mirrors the duplicate-check flow in createLink.ts but without a max attempt limit
+        // Note: Each vainId call advances the iterator internally
+        while (true) {
+            const vainIdResp = await client.queries.vainId({}, { authMode: 'userPool' });
+            const candidateId = vainIdResp?.data?.id || '';
+
+            if (!candidateId) {
+                // If we failed to get an ID for some reason, try again
+                continue;
+            }
+
+            try {
+                const existing = await client.models.ShortenedUrl.get({ id: candidateId }, { authMode: 'userPool' });
+                const isDuplicate = !!existing?.data;
+
+                if (!isDuplicate) {
+                    break; // Found a free ID; iterator now points to the next available slot
+                }
+                // else: continue loop to advance to next ID
+            } catch {
+                // On errors fetching, assume not a duplicate and break to avoid stalling
+                break;
+            }
+        }
+
+        // Step 3: Decrement iterator by one so the next normal generation yields the found unique ID
+        const currentIterResp = await client.models.iterator.get({ id: 'lytnit' }, { authMode: 'userPool' });
+        const currentIteration = currentIterResp?.data?.iteration ?? 0;
+        const nextIteration = Math.max(0, currentIteration - 1);
+        // console.log('[IMPORT] updateIterator: decrementing iterator', { from: currentIteration, to: nextIteration });
+        await client.models.iterator.update({
+            id: 'lytnit',
+            iteration: nextIteration
+        }, { authMode: 'userPool' });
+    };
+
+    try {
+        const successfulImports = [];
+        const failedImports = [];
+
+        for (const link of links) {
+            // Prepare the data object with required fields
+            // Sanitize and validate the destination URL
+            const sanitizedDestination = sanitizeUrl(link.destination);
+            
+            const linkData: ShortenedUrlData = {
+                id: link.id,
+                destination: sanitizedDestination,
+                source: 'upload',
+                owner: null
+            };
+
+            // console.debug('[IMPORT] Attempting create ShortenedUrl', { id: linkData.id, destination: linkData.destination, source: linkData.source, hasOwner: !!linkData.owner, status: linkData.status });
+            const result = await client.models.ShortenedUrl.create(linkData, { authMode: 'userPool' });
+
+            console.log('[IMPORT] result', result);
+
+            if (result?.data?.id) {
+                // console.log('[IMPORT] Created ShortenedUrl', { id: result.data.id });
+                successfulImports.push(result.data);
+            } else {
+                if (updateDuplicates) {
+                    // console.log('[IMPORT] Create returned no id; attempting update for potential duplicate', { id: linkData.id });
+                    await client.models.ShortenedUrl.update(linkData, { authMode: 'userPool' });
+                } else {
+                    // console.warn('[IMPORT] Failed to create ShortenedUrl and duplicates not updated; marking as failed', { id: linkData.id });
+                    failedImports.push(link);
+                }
+            }
+        }
+
+        // After processing all links, update the iterator only when not updating duplicates
+        if (!updateDuplicates) {
+            console.log('[IMPORT] Updating iterator after import', { incrementBy: links.length });
+            await updateIterator(links.length);
+        }
+
+        // const summary = { successfulCount: successfulImports.length, failedCount: failedImports.length };
+        // console.log('[IMPORT] Finished import run', summary);
+        console.timeEnd('[IMPORT] importHandler total');
+        return {
+            successfulImports,
+            failedImports
+        };
+    } catch (error) {
+        console.error('[IMPORT] Error importing links:', error);
+        console.timeEnd('[IMPORT] importHandler total');
+    }
+}

--- a/src/utilities/import-links.ts
+++ b/src/utilities/import-links.ts
@@ -100,8 +100,13 @@ export const importLinks = async (links: LinkToImport[], updateDuplicates: boole
     try {
         const successfulImports = [];
         const failedImports = [];
+        let currentIndex = 0;
 
         for (const link of links) {
+            currentIndex++;
+            console.clear();
+            console.log(`[IMPORT] Processing ${currentIndex}/${links.length}`);
+
             // Prepare the data object with required fields
             // Sanitize and validate the destination URL
             const sanitizedDestination = sanitizeUrl(link.destination);
@@ -116,7 +121,7 @@ export const importLinks = async (links: LinkToImport[], updateDuplicates: boole
             // console.debug('[IMPORT] Attempting create ShortenedUrl', { id: linkData.id, destination: linkData.destination, source: linkData.source, hasOwner: !!linkData.owner, status: linkData.status });
             const result = await client.models.ShortenedUrl.create(linkData, { authMode: 'userPool' });
 
-            console.log('[IMPORT] result', result);
+            // console.log('[IMPORT] result', result);
 
             if (result?.data?.id) {
                 // console.log('[IMPORT] Created ShortenedUrl', { id: result.data.id });
@@ -140,13 +145,13 @@ export const importLinks = async (links: LinkToImport[], updateDuplicates: boole
 
         // const summary = { successfulCount: successfulImports.length, failedCount: failedImports.length };
         // console.log('[IMPORT] Finished import run', summary);
-        console.timeEnd('[IMPORT] importHandler total');
+        // console.timeEnd('[IMPORT] importHandler total');
         return {
             successfulImports,
             failedImports
         };
     } catch (error) {
         console.error('[IMPORT] Error importing links:', error);
-        console.timeEnd('[IMPORT] importHandler total');
+        // console.timeEnd('[IMPORT] importHandler total');
     }
 }

--- a/src/utilities/import-links.ts
+++ b/src/utilities/import-links.ts
@@ -166,5 +166,9 @@ export const importLinks = async (links: LinkToImport[], updateDuplicates: boole
     } catch (error) {
         console.error('[IMPORT] Error importing links:', error);
         // console.timeEnd('[IMPORT] importHandler total');
+        return {
+            successfulImports: [],
+            failedImports: links // Return all links as failed when an error occurs
+        };
     }
 }


### PR DESCRIPTION
This PR moves the import function to the client side.

It also adds a progress counter in the console to monitor the progress of the importing, and fixes a bug where some imported url's may have spaces and need to be converted into proper url's for graphql's url type.